### PR TITLE
Add regional fee surcharge support

### DIFF
--- a/custom_components/ekz_tariffs/__init__.py
+++ b/custom_components/ekz_tariffs/__init__.py
@@ -17,12 +17,14 @@ from .const import (
     CONF_AUTH_TYPE,
     CONF_EMS_INSTANCE_ID,
     CONF_INCLUDE_VAT,
+    CONF_REGIONAL_FEE,
     CONF_TARIFF_NAME,
     DEFAULT_TARIFF_NAME,
     DOMAIN,
     FETCH_HOUR,
     FETCH_MINUTE,
     PLATFORMS,
+    REGIONAL_FEE_NONE,
     SERVICE_CHECK_EMS_LINK_STATUS,
     SERVICE_REFRESH,
 )
@@ -65,8 +67,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         session = async_get_clientsession(hass)
         api = EkzTariffsOAuthApi(oauth_session, session)
         include_vat = entry.data.get(CONF_INCLUDE_VAT, False)
+        regional_fee = entry.data.get(CONF_REGIONAL_FEE, REGIONAL_FEE_NONE)
         coordinator = EkzTariffsOAuthCoordinator(
-            hass, api, store, ems_instance_id, incl_vat=include_vat
+            hass,
+            api,
+            store,
+            ems_instance_id,
+            incl_vat=include_vat,
+            regional_fee=regional_fee,
         )
 
         # Create EMS link status coordinator
@@ -118,10 +126,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Public API setup
         tariff_name = entry.data.get(CONF_TARIFF_NAME, DEFAULT_TARIFF_NAME)
         include_vat = entry.data.get(CONF_INCLUDE_VAT, False)
+        regional_fee = entry.data.get(CONF_REGIONAL_FEE, REGIONAL_FEE_NONE)
         session = async_get_clientsession(hass)
         api = EkzTariffsApi(session)
         coordinator = EkzTariffsCoordinator(
-            hass, api, tariff_name, store, incl_vat=include_vat
+            hass,
+            api,
+            tariff_name,
+            store,
+            incl_vat=include_vat,
+            regional_fee=regional_fee,
         )
 
         device_name = f"EKZ Tariff {tariff_name}"

--- a/custom_components/ekz_tariffs/api.py
+++ b/custom_components/ekz_tariffs/api.py
@@ -15,6 +15,7 @@ from .const import (
     API_EMS_LINK_STATUS_PATH,
     API_TARIFFS_PATH,
     INTEGRATED_PREFIX,
+    REGIONAL_FEE_NONE,
     VAT_RATE,
 )
 
@@ -56,6 +57,7 @@ class EkzTariffsApi:
         start: datetime,
         end: datetime,
         incl_vat: bool = False,
+        regional_fee: str | None = None,
     ) -> list[TariffSlot]:
         """Fetch tariff slots from EKZ public API for time range."""
         start = dt_util.as_local(start)
@@ -73,7 +75,54 @@ class EkzTariffsApi:
             resp.raise_for_status()
             data: dict[str, Any] = await resp.json()
 
-        return self._parse_tariff_slots(data, incl_vat=incl_vat)
+        slots = self._parse_tariff_slots(data, incl_vat=incl_vat)
+
+        if regional_fee and regional_fee != REGIONAL_FEE_NONE:
+            regional_price = await self._fetch_regional_fee_price(
+                regional_fee, start, end
+            )
+            if regional_price is not None:
+                if incl_vat:
+                    regional_price = regional_price * (1 + VAT_RATE)
+                slots = [
+                    TariffSlot(
+                        start=s.start,
+                        end=s.end,
+                        price_chf_per_kwh=round(
+                            s.price_chf_per_kwh + regional_price, 4
+                        ),
+                    )
+                    for s in slots
+                ]
+
+        return slots
+
+    async def _fetch_regional_fee_price(
+        self, fee_name: str, start: datetime, end: datetime
+    ) -> float | None:
+        """Fetch a regional fee tariff and return its CHF_kWh price."""
+        params = {
+            "tariff_name": fee_name,
+            "start_timestamp": start.isoformat(timespec="seconds"),
+            "end_timestamp": end.isoformat(timespec="seconds"),
+        }
+        url = f"{API_BASE}{API_TARIFFS_PATH}"
+
+        try:
+            async with self._session.get(url, params=params, timeout=30) as resp:
+                resp.raise_for_status()
+                data: dict[str, Any] = await resp.json()
+        except Exception:
+            _LOGGER.exception("Failed to fetch regional fee %s", fee_name)
+            return None
+
+        # Regional fee responses use the "regional_fees" key instead of "integrated"
+        for item in data.get("prices", []):
+            for comp in item.get("regional_fees", []):
+                if comp.get("unit") == "CHF_kWh":
+                    return float(comp.get("value", 0))
+
+        return None
 
     def _parse_tariff_slots(
         self, data: dict[str, Any], incl_vat: bool = False
@@ -100,7 +149,7 @@ class EkzTariffsApi:
                 TariffSlot(
                     start=dt_util.as_local(start_ts),
                     end=dt_util.as_local(end_ts),
-                    price_chf_per_kwh=float(price_val),
+                    price_chf_per_kwh=round(float(price_val), 4),
                 )
             )
 
@@ -128,6 +177,7 @@ class EkzTariffsOAuthApi:
         start: datetime,
         end: datetime,
         incl_vat: bool = False,
+        regional_fee: str | bool | None = None,
     ) -> list[TariffSlot]:
         """Fetch customer-specific tariffs from authenticated API."""
         start = dt_util.as_local(start)
@@ -155,7 +205,9 @@ class EkzTariffsOAuthApi:
             resp.raise_for_status()
             data: dict[str, Any] = await resp.json()
 
-        # Parse the response similar to public API
+        # Parse the response — /customerTariffs returns all tariff types
+        # (integrated, regional_fees, etc.) in one response when no
+        # tariff_type filter is given.
         slots: list[TariffSlot] = []
         for item in data.get("prices", []):
             start_ts = dt_util.parse_datetime(item["start_timestamp"])
@@ -166,18 +218,25 @@ class EkzTariffsOAuthApi:
             for comp in item.get("integrated", []):
                 if comp.get("unit") == "CHF_kWh":
                     price_val = comp.get("value")
-                    if incl_vat:
-                        price_val = price_val * (1 + VAT_RATE)
                     break
 
             if price_val is None:
                 continue
 
+            # Sum regional fees from the same response (no extra API call)
+            if regional_fee and regional_fee != REGIONAL_FEE_NONE:
+                for comp in item.get("regional_fees", []):
+                    if comp.get("unit") == "CHF_kWh":
+                        price_val += comp.get("value")
+
+            if incl_vat:
+                price_val = price_val * (1 + VAT_RATE)
+
             slots.append(
                 TariffSlot(
                     start=dt_util.as_local(start_ts),
                     end=dt_util.as_local(end_ts),
-                    price_chf_per_kwh=float(price_val),
+                    price_chf_per_kwh=round(float(price_val), 4),
                 )
             )
 

--- a/custom_components/ekz_tariffs/config_flow.py
+++ b/custom_components/ekz_tariffs/config_flow.py
@@ -17,10 +17,13 @@ from .const import (
     CONF_AUTH_TYPE,
     CONF_EMS_INSTANCE_ID,
     CONF_INCLUDE_VAT,
+    CONF_REGIONAL_FEE,
     CONF_TARIFF_NAME,
     DEFAULT_TARIFF_NAME,
     DOMAIN,
     OAUTH2_SCOPES,
+    REGIONAL_FEE_CHOICES,
+    REGIONAL_FEE_NONE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -88,6 +91,9 @@ class OAuth2FlowHandler(
                         TARIFF_CHOICES
                     ),
                     vol.Optional(CONF_INCLUDE_VAT, default=False): bool,
+                    vol.Optional(
+                        CONF_REGIONAL_FEE, default=REGIONAL_FEE_NONE
+                    ): vol.In(REGIONAL_FEE_CHOICES),
                 }
             )
             return self.async_show_form(step_id="public_config", data_schema=schema)
@@ -103,6 +109,7 @@ class OAuth2FlowHandler(
                 CONF_AUTH_TYPE: AUTH_TYPE_PUBLIC,
                 CONF_TARIFF_NAME: user_input[CONF_TARIFF_NAME],
                 CONF_INCLUDE_VAT: user_input.get(CONF_INCLUDE_VAT, False),
+                CONF_REGIONAL_FEE: user_input.get(CONF_REGIONAL_FEE, REGIONAL_FEE_NONE),
             },
         )
 
@@ -214,11 +221,12 @@ class OAuth2FlowHandler(
     async def async_step_ems_linking_complete(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Complete the config flow after EMS linking - ask for VAT preference."""
+        """Complete the config flow after EMS linking - ask for VAT and regional fee preferences."""
         if user_input is None:
             schema = vol.Schema(
                 {
                     vol.Optional(CONF_INCLUDE_VAT, default=False): bool,
+                    vol.Optional(CONF_REGIONAL_FEE, default=False): bool,
                 }
             )
             return self.async_show_form(
@@ -235,6 +243,9 @@ class OAuth2FlowHandler(
                 CONF_AUTH_TYPE: AUTH_TYPE_OAUTH,
                 CONF_EMS_INSTANCE_ID: self.ems_instance_id,
                 CONF_INCLUDE_VAT: user_input.get(CONF_INCLUDE_VAT, False),
+                CONF_REGIONAL_FEE: user_input.get(
+                    CONF_REGIONAL_FEE, REGIONAL_FEE_NONE
+                ),
                 **self.oauth_data,
             },
         )
@@ -272,19 +283,44 @@ class EkzTariffsOptionsFlow(config_entries.OptionsFlow):
                 data={
                     **self.config_entry.data,
                     CONF_INCLUDE_VAT: user_input[CONF_INCLUDE_VAT],
+                    CONF_REGIONAL_FEE: user_input[CONF_REGIONAL_FEE],
                 },
             )
             # Reload the integration to apply changes
             await self.hass.config_entries.async_reload(self.config_entry.entry_id)
             return self.async_create_entry(title="", data={})
 
-        # Get current value from config entry
+        # Get current values from config entry
         current_include_vat = self.config_entry.data.get(CONF_INCLUDE_VAT, False)
-
-        schema = vol.Schema(
-            {
-                vol.Optional(CONF_INCLUDE_VAT, default=current_include_vat): bool,
-            }
+        auth_type = self.config_entry.data.get(CONF_AUTH_TYPE)
+        current_regional_fee = self.config_entry.data.get(
+            CONF_REGIONAL_FEE, REGIONAL_FEE_NONE
         )
+
+        # OAuth path: checkbox (API returns the customer's actual fees)
+        # Public path: dropdown (user must select the right regional fee)
+        if auth_type == AUTH_TYPE_OAUTH:
+            regional_fee_default = bool(
+                current_regional_fee
+                and current_regional_fee != REGIONAL_FEE_NONE
+            )
+            regional_fee_field = vol.Optional(
+                CONF_REGIONAL_FEE, default=regional_fee_default
+            )
+            schema = vol.Schema(
+                {
+                    vol.Optional(CONF_INCLUDE_VAT, default=current_include_vat): bool,
+                    regional_fee_field: bool,
+                }
+            )
+        else:
+            schema = vol.Schema(
+                {
+                    vol.Optional(CONF_INCLUDE_VAT, default=current_include_vat): bool,
+                    vol.Optional(
+                        CONF_REGIONAL_FEE, default=current_regional_fee
+                    ): vol.In(REGIONAL_FEE_CHOICES),
+                }
+            )
 
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/ekz_tariffs/config_flow.py
+++ b/custom_components/ekz_tariffs/config_flow.py
@@ -91,9 +91,9 @@ class OAuth2FlowHandler(
                         TARIFF_CHOICES
                     ),
                     vol.Optional(CONF_INCLUDE_VAT, default=False): bool,
-                    vol.Optional(
-                        CONF_REGIONAL_FEE, default=REGIONAL_FEE_NONE
-                    ): vol.In(REGIONAL_FEE_CHOICES),
+                    vol.Optional(CONF_REGIONAL_FEE, default=REGIONAL_FEE_NONE): vol.In(
+                        REGIONAL_FEE_CHOICES
+                    ),
                 }
             )
             return self.async_show_form(step_id="public_config", data_schema=schema)
@@ -243,9 +243,7 @@ class OAuth2FlowHandler(
                 CONF_AUTH_TYPE: AUTH_TYPE_OAUTH,
                 CONF_EMS_INSTANCE_ID: self.ems_instance_id,
                 CONF_INCLUDE_VAT: user_input.get(CONF_INCLUDE_VAT, False),
-                CONF_REGIONAL_FEE: user_input.get(
-                    CONF_REGIONAL_FEE, REGIONAL_FEE_NONE
-                ),
+                CONF_REGIONAL_FEE: user_input.get(CONF_REGIONAL_FEE, REGIONAL_FEE_NONE),
                 **self.oauth_data,
             },
         )
@@ -301,8 +299,7 @@ class EkzTariffsOptionsFlow(config_entries.OptionsFlow):
         # Public path: dropdown (user must select the right regional fee)
         if auth_type == AUTH_TYPE_OAUTH:
             regional_fee_default = bool(
-                current_regional_fee
-                and current_regional_fee != REGIONAL_FEE_NONE
+                current_regional_fee and current_regional_fee != REGIONAL_FEE_NONE
             )
             regional_fee_field = vol.Optional(
                 CONF_REGIONAL_FEE, default=regional_fee_default

--- a/custom_components/ekz_tariffs/const.py
+++ b/custom_components/ekz_tariffs/const.py
@@ -7,6 +7,15 @@ CONF_TARIFF_NAME = "tariff_name"
 CONF_AUTH_TYPE = "auth_type"
 CONF_EMS_INSTANCE_ID = "ems_instance_id"
 CONF_INCLUDE_VAT = "include_vat"
+CONF_REGIONAL_FEE = "regional_fee"
+REGIONAL_FEE_NONE = "none"
+REGIONAL_FEE_CHOICES = [
+    "none",
+    "regional_fees_lt500MWh_ZH",
+    "regional_fees_gt500MWh_ZH",
+    "regional_fees_Menzingen",
+    "regional_fees_Einsiedeln",
+]
 AUTH_TYPE_PUBLIC = "public"
 AUTH_TYPE_OAUTH = "oauth"
 DEFAULT_TARIFF_NAME = "400D"

--- a/custom_components/ekz_tariffs/coordinator.py
+++ b/custom_components/ekz_tariffs/coordinator.py
@@ -58,6 +58,7 @@ class EkzTariffsCoordinator(DataUpdateCoordinator[list[TariffSlot]]):
         tariff_name: str,
         store: Store,
         incl_vat: bool = False,
+        regional_fee: str | None = None,
     ):
         super().__init__(
             hass,
@@ -70,6 +71,7 @@ class EkzTariffsCoordinator(DataUpdateCoordinator[list[TariffSlot]]):
         self._tariff_name = tariff_name
         self._store = store
         self._incl_vat = incl_vat
+        self._regional_fee = regional_fee
 
     async def _async_update_data(self) -> list[TariffSlot]:
         try:
@@ -87,6 +89,7 @@ class EkzTariffsCoordinator(DataUpdateCoordinator[list[TariffSlot]]):
                 start=start,
                 end=end,
                 incl_vat=self._incl_vat,
+                regional_fee=self._regional_fee,
             )
             await self._store.async_save({"slots": slots_to_json(slots)})
             return slots
@@ -104,6 +107,7 @@ class EkzTariffsOAuthCoordinator(DataUpdateCoordinator[list[TariffSlot]]):
         store: Store,
         ems_instance_id: str,
         incl_vat: bool = False,
+        regional_fee: str | bool | None = None,
     ):
         super().__init__(
             hass,
@@ -116,6 +120,7 @@ class EkzTariffsOAuthCoordinator(DataUpdateCoordinator[list[TariffSlot]]):
         self._store = store
         self._ems_instance_id = ems_instance_id
         self._incl_vat = incl_vat
+        self._regional_fee = regional_fee
 
     async def _async_update_data(self) -> list[TariffSlot]:
         try:
@@ -133,6 +138,7 @@ class EkzTariffsOAuthCoordinator(DataUpdateCoordinator[list[TariffSlot]]):
                 start=start,
                 end=end,
                 incl_vat=self._incl_vat,
+                regional_fee=self._regional_fee,
             )
             await self._store.async_save({"slots": slots_to_json(slots)})
             return slots

--- a/custom_components/ekz_tariffs/translations/de.json
+++ b/custom_components/ekz_tariffs/translations/de.json
@@ -13,7 +13,8 @@
         "description": "Wählen Sie Ihren Tarifplan",
         "data": {
           "tariff_name": "Tarifname",
-          "include_vat": "MwSt. einbeziehen (8,1%)"
+          "include_vat": "MwSt. einbeziehen (8,1%)",
+          "regional_fee": "Regionale Abgabe"
         }
       },
       "pick_implementation": {
@@ -27,7 +28,8 @@
         "title": "Kundentarif-Optionen konfigurieren",
         "description": "Konfigurieren Sie, wie Sie Ihre kundenspezifischen Tarifpreise anzeigen möchten",
         "data": {
-          "include_vat": "MwSt. einbeziehen (8,1%)"
+          "include_vat": "MwSt. einbeziehen (8,1%)",
+          "regional_fee": "Regionale Abgabe"
         }
       }
     },
@@ -48,7 +50,8 @@
         "title": "EKZ Tarife Optionen konfigurieren",
         "description": "Einstellungen für Ihre Tarifintegration anpassen",
         "data": {
-          "include_vat": "MwSt. einbeziehen (8,1%)"
+          "include_vat": "MwSt. einbeziehen (8,1%)",
+          "regional_fee": "Regionale Abgabe"
         }
       }
     }

--- a/custom_components/ekz_tariffs/translations/en.json
+++ b/custom_components/ekz_tariffs/translations/en.json
@@ -13,7 +13,8 @@
         "description": "Select your tariff plan",
         "data": {
           "tariff_name": "Tariff Name",
-          "include_vat": "Include VAT (8.1%)"
+          "include_vat": "Include VAT (8.1%)",
+          "regional_fee": "Regional fee surcharge"
         }
       },
       "pick_implementation": {
@@ -27,7 +28,8 @@
         "title": "Configure Customer Tariff Options",
         "description": "Configure how you want to display your customer-specific tariff prices",
         "data": {
-          "include_vat": "Include VAT (8.1%)"
+          "include_vat": "Include VAT (8.1%)",
+          "regional_fee": "Include regional fees"
         }
       }
     },
@@ -48,7 +50,8 @@
         "title": "Configure EKZ Tariffs Options",
         "description": "Adjust settings for your tariff integration",
         "data": {
-          "include_vat": "Include VAT (8.1%)"
+          "include_vat": "Include VAT (8.1%)",
+          "regional_fee": "Regional fee surcharge"
         }
       }
     }

--- a/custom_components/ekz_tariffs/translations/fr.json
+++ b/custom_components/ekz_tariffs/translations/fr.json
@@ -13,7 +13,8 @@
         "description": "Sélectionnez votre plan tarifaire",
         "data": {
           "tariff_name": "Nom du tarif",
-          "include_vat": "Inclure la TVA (8,1%)"
+          "include_vat": "Inclure la TVA (8,1%)",
+          "regional_fee": "Redevance régionale"
         }
       },
       "pick_implementation": {
@@ -27,7 +28,8 @@
         "title": "Configurer les options de tarif client",
         "description": "Configurez comment vous souhaitez afficher vos prix tarifaires spécifiques au client",
         "data": {
-          "include_vat": "Inclure la TVA (8,1%)"
+          "include_vat": "Inclure la TVA (8,1%)",
+          "regional_fee": "Redevance régionale"
         }
       }
     },
@@ -48,7 +50,8 @@
         "title": "Configurer les options des tarifs EKZ",
         "description": "Ajuster les paramètres de votre intégration tarifaire",
         "data": {
-          "include_vat": "Inclure la TVA (8,1%)"
+          "include_vat": "Inclure la TVA (8,1%)",
+          "regional_fee": "Redevance régionale"
         }
       }
     }

--- a/custom_components/ekz_tariffs/translations/it.json
+++ b/custom_components/ekz_tariffs/translations/it.json
@@ -13,7 +13,8 @@
         "description": "Seleziona il tuo piano tariffario",
         "data": {
           "tariff_name": "Nome tariffa",
-          "include_vat": "Includi IVA (8,1%)"
+          "include_vat": "Includi IVA (8,1%)",
+          "regional_fee": "Supplemento regionale"
         }
       },
       "pick_implementation": {
@@ -27,7 +28,8 @@
         "title": "Configura opzioni tariffa cliente",
         "description": "Configura come desideri visualizzare i prezzi tariffari specifici del cliente",
         "data": {
-          "include_vat": "Includi IVA (8,1%)"
+          "include_vat": "Includi IVA (8,1%)",
+          "regional_fee": "Supplemento regionale"
         }
       }
     },
@@ -48,7 +50,8 @@
         "title": "Configura opzioni tariffe EKZ",
         "description": "Regola le impostazioni per la tua integrazione tariffaria",
         "data": {
-          "include_vat": "Includi IVA (8,1%)"
+          "include_vat": "Includi IVA (8,1%)",
+          "regional_fee": "Supplemento regionale"
         }
       }
     }


### PR DESCRIPTION
EKZ integrated tariffs (e.g., `integrated_400F`) exclude regional fees like the **Förderung Energieeffizienz** (0.17 Rp./kWh). The API provides these as separate tariffs.

## Changes

### Public API path
- New dropdown in setup: select which regional fee applies (or none)
- Integration fetches the selected fee from `/v1/tariffs` and sums the `CHF_kWh` values
- Available options: none, `regional_fees_lt500MWh_ZH`, `regional_fees_gt500MWh_ZH`, `regional_fees_Menzingen`, `regional_fees_Einsiedeln`

### OAuth path
- New checkbox in setup: "Include regional fees"
- `/v1/customerTariffs` already returns `regional_fees` alongside `integrated` in one response — no extra API call needed

### Price rounding
- Prices now rounded to 4 decimal places, matching EKZ tariff sheets (Rp./kWh precision)

### Result
For 400F: **0.2111 CHF/kWh → 0.2128 CHF/kWh** ✓

Fixes #3